### PR TITLE
Make wheel emulator tunable via config

### DIFF
--- a/control_app/domain/src/main/java/com/rc/playgrounds/config/Config.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/config/Config.kt
@@ -33,6 +33,7 @@ data class Config(
         rawSteerZone = null,
         rawForwardLongZones = emptyMap(),
         rawBackwardLongZones = emptyMap(),
+        wheel = null,
     ),
 ) {
     fun writeToJson(): String {
@@ -76,6 +77,7 @@ data class Config(
                             rawSteerZone = null,
                             rawForwardLongZones = emptyMap(),
                             rawBackwardLongZones = emptyMap(),
+                            wheel = null,
                         )
                     )
                 }
@@ -155,8 +157,18 @@ internal const val DEFAULT_CONFIG = """
     "backward_long_zones": {
         "0.0": "0.01",
         "1.0": "0.2"
+    },
+    "wheel": {
+      "max_angle_deg": 28.0,
+      "max_turn_rate_deg_per_sec": 420.0,
+      "center_return_rate_deg_per_sec": 140.0,
+      "deadzone": 0.06,
+      "curve_blend": 0.55,
+      "ema_cutoff_hz": 10.0,
+      "center_stick_threshold": 0.02,
+      "damping": 0.9
     }
   }
-}    
+}
 """
 

--- a/control_app/domain/src/main/java/com/rc/playgrounds/config/model/ControlTuning.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/config/model/ControlTuning.kt
@@ -40,6 +40,9 @@ data class ControlTuning(
      */
     @SerialName("backward_long_zones")
     val rawBackwardLongZones: Map<String, String> = emptyMap(),
+
+    @SerialName("wheel")
+    val wheel: WheelConfig? = null,
 ) {
     @Transient
     val pitchZone: PointF? = Zones.parseZone(rawPitchZone)

--- a/control_app/domain/src/main/java/com/rc/playgrounds/config/model/WheelConfig.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/config/model/WheelConfig.kt
@@ -1,0 +1,16 @@
+package com.rc.playgrounds.config.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class WheelConfig(
+    @SerialName("max_angle_deg") val maxAngleDeg: Float? = null,
+    @SerialName("max_turn_rate_deg_per_sec") val maxTurnRateDegPerSec: Float? = null,
+    @SerialName("center_return_rate_deg_per_sec") val centerReturnRateDegPerSec: Float? = null,
+    @SerialName("deadzone") val deadzone: Float? = null,
+    @SerialName("curve_blend") val curveBlend: Float? = null,
+    @SerialName("ema_cutoff_hz") val emaCutoffHz: Float? = null,
+    @SerialName("center_stick_threshold") val centerStickThreshold: Float? = null,
+    @SerialName("damping") val damping: Float? = null,
+)


### PR DESCRIPTION
## Summary
- group wheel emulator parameters under new `WheelConfig` inside `ControlTuning`
- update default config and `SteerProvider` to read wheel settings from nested config

## Testing
- `./gradlew test` *(fails: GSTREAMER_ROOT_ANDROID must be set in env, or 'gstAndroidRoot' must be defined in your local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a15fa7c832baebfd46ed7a7c3bc