### PR TITLE
feat: introduce named control profiles

### DIFF
--- a/control_app/domain/src/main/java/com/rc/playgrounds/AppComponent.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/AppComponent.kt
@@ -5,6 +5,7 @@ import com.rc.playgrounds.config.ActiveConfigProvider
 import com.rc.playgrounds.config.ConfigRepository
 import com.rc.playgrounds.config.view.ConfigModel
 import com.rc.playgrounds.control.ControlInterpolationProvider
+import com.rc.playgrounds.control.ControlTuningProvider
 import com.rc.playgrounds.control.RcEventStream
 import com.rc.playgrounds.control.gamepad.GamePadEventSessionProvider
 import com.rc.playgrounds.control.gamepad.GamepadEventStream
@@ -58,13 +59,17 @@ class AppComponent(app: Application) {
         gamepadEventStream,
     )
     private val controlLock = ControlLock()
-    private val controlInterpolationProvider = ControlInterpolationProvider(
+    private val controlTuningProvider = ControlTuningProvider(
         activeConfigProvider,
+    )
+    private val controlInterpolationProvider = ControlInterpolationProvider(
+        controlTuningProvider,
     )
     private val steerProvider = SteerProvider(
         gamePadEventSessionProvider,
         controlInterpolationProvider,
         activeConfigProvider,
+        controlTuningProvider,
         scope,
     )
     private val rcEventStream = RcEventStream(

--- a/control_app/domain/src/main/java/com/rc/playgrounds/config/Config.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/config/Config.kt
@@ -7,6 +7,7 @@ import com.rc.playgrounds.config.stream.QualityProfile
 import com.rc.playgrounds.config.stream.StreamConfig
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.Json
 import org.intellij.lang.annotations.Language
 
@@ -24,18 +25,23 @@ data class Config(
         steer = 0f,
         long = 0f,
     ),
-    @SerialName("control_tuning")
-    val controlTuning: ControlTuning = ControlTuning(
-        pitchFactor = 0f,
-        rawPitchZone = null,
-        yawFactor = 0f,
-        rawYawZone = null,
-        rawSteerZone = null,
-        rawForwardLongZones = emptyMap(),
-        rawBackwardLongZones = emptyMap(),
-        wheel = null,
+    @SerialName("control_profiles")
+    val controlProfiles: List<ControlTuning> = listOf(
+        ControlTuning(
+            pitchFactor = 0f,
+            rawPitchZone = null,
+            yawFactor = 0f,
+            rawYawZone = null,
+            rawSteerZone = null,
+            rawForwardLongZones = emptyMap(),
+            rawBackwardLongZones = emptyMap(),
+            wheel = null,
+        )
     ),
 ) {
+    @Transient
+    val controlTuning: ControlTuning = controlProfiles.first()
+
     fun writeToJson(): String {
         return jsonParser.encodeToString(Config.serializer(), this)
     }
@@ -69,15 +75,17 @@ data class Config(
                             steer = 0f,
                             long = 0f,
                         ),
-                        controlTuning = ControlTuning(
-                            pitchFactor = 0f,
-                            rawPitchZone = null,
-                            yawFactor = 0f,
-                            rawYawZone = null,
-                            rawSteerZone = null,
-                            rawForwardLongZones = emptyMap(),
-                            rawBackwardLongZones = emptyMap(),
-                            wheel = null,
+                        controlProfiles = listOf(
+                            ControlTuning(
+                                pitchFactor = 0f,
+                                rawPitchZone = null,
+                                yawFactor = 0f,
+                                rawYawZone = null,
+                                rawSteerZone = null,
+                                rawForwardLongZones = emptyMap(),
+                                rawBackwardLongZones = emptyMap(),
+                                wheel = null,
+                            )
                         )
                     )
                 }
@@ -138,38 +146,41 @@ internal const val DEFAULT_CONFIG = """
     "steer": 0.08,
     "long": 0.18
   },
-  "control_tuning": {
-    "pitch_factor": 1.0,
-    "pitch_zone": "0..0.5",
-    "yaw_factor": 1.0,
-    "yaw_zone": "0..0.5",
-    "steer_zone": "0..0.7",
-    "steer_limit_at_trigger": {
-        "0.0": "1.0",
-        "0.5": "0.7",
-        "1.0": "0.3"
-    },
-    "forward_long_zones": {
-        "0.0": "0.01",
-        "0.5": "0.2",
-        "1.0": "0.7"
-    },
-    "backward_long_zones": {
-        "0.0": "0.01",
-        "1.0": "0.2"
-    },
-    "wheel": {
-      "_comment_": "All values are optional. See: WheelEmulator.kt",
-      "max_angle_deg": 28.0,
-      "max_turn_rate_deg_per_sec": 420.0,
-      "center_return_rate_deg_per_sec": 140.0,
-      "deadzone": 0.06,
-      "curve_blend": 0.55,
-      "ema_cutoff_hz": 10.0,
-      "center_stick_threshold": 0.02,
-      "damping": 0.9
+  "control_profiles": [
+    {
+      "name": "default",
+      "pitch_factor": 1.0,
+      "pitch_zone": "0..0.5",
+      "yaw_factor": 1.0,
+      "yaw_zone": "0..0.5",
+      "steer_zone": "0..0.7",
+      "steer_limit_at_trigger": {
+          "0.0": "1.0",
+          "0.5": "0.7",
+          "1.0": "0.3"
+      },
+      "forward_long_zones": {
+          "0.0": "0.01",
+          "0.5": "0.2",
+          "1.0": "0.7"
+      },
+      "backward_long_zones": {
+          "0.0": "0.01",
+          "1.0": "0.2"
+      },
+      "wheel": {
+        "_comment_": "All values are optional. See: WheelEmulator.kt",
+        "max_angle_deg": 28.0,
+        "max_turn_rate_deg_per_sec": 420.0,
+        "center_return_rate_deg_per_sec": 140.0,
+        "deadzone": 0.06,
+        "curve_blend": 0.55,
+        "ema_cutoff_hz": 10.0,
+        "center_stick_threshold": 0.02,
+        "damping": 0.9
+      }
     }
-  }
+  ]
 }
 """
 

--- a/control_app/domain/src/main/java/com/rc/playgrounds/config/model/ControlTuning.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/config/model/ControlTuning.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class ControlTuning(
+    @SerialName("name")
+    val name: String? = null,
     @SerialName("pitch_factor")
     val pitchFactor: Float? = null,
     @SerialName("pitch_zone")

--- a/control_app/domain/src/main/java/com/rc/playgrounds/control/ControlInterpolation.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/control/ControlInterpolation.kt
@@ -2,7 +2,6 @@ package com.rc.playgrounds.control
 
 import android.graphics.PointF
 import android.view.animation.AccelerateInterpolator
-import com.rc.playgrounds.config.ActiveConfigProvider
 import com.rc.playgrounds.config.model.ControlTuning
 import com.rc.playgrounds.config.model.MappingZone
 import com.rc.playgrounds.control.steering.SteerValue
@@ -13,10 +12,10 @@ import kotlin.math.sign
 import kotlin.math.withSign
 
 class ControlInterpolationProvider(
-    private val activeConfigProvider: ActiveConfigProvider,
+    private val controlTuningProvider: ControlTuningProvider,
 ) {
-    val interpolation: Flow<ControlInterpolation> = activeConfigProvider.configFlow.map {
-        it.controlTuning.asInterpolation()
+    val interpolation: Flow<ControlInterpolation> = controlTuningProvider.controlTuning.map {
+        it.asInterpolation()
     }
 }
 

--- a/control_app/domain/src/main/java/com/rc/playgrounds/control/ControlTuningProvider.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/control/ControlTuningProvider.kt
@@ -1,0 +1,13 @@
+package com.rc.playgrounds.control
+
+import com.rc.playgrounds.config.ActiveConfigProvider
+import com.rc.playgrounds.config.model.ControlTuning
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class ControlTuningProvider(
+    private val activeConfigProvider: ActiveConfigProvider,
+) {
+    val controlTuning: Flow<ControlTuning> = activeConfigProvider.configFlow.map { it.controlTuning }
+}
+

--- a/control_app/domain/src/test/java/com/rc/playgrounds/config/ConfigTest.kt
+++ b/control_app/domain/src/test/java/com/rc/playgrounds/config/ConfigTest.kt
@@ -69,7 +69,8 @@ class ConfigTest {
                 "steer": 0.0,
                 "long": 0.0
             },
-            "control_tuning": {
+            "control_profiles": [{
+                "name": "default",
                 "forward_long_zones": {
                     "0": "0.01",
                     "0.3": "0.21",
@@ -77,7 +78,7 @@ class ConfigTest {
                     "0.9": "0.5",
                     "1": "0.7"
                 }
-            }
+            }]
         }""".trimIndent()
         val config = Config(json) {
             throw it


### PR DESCRIPTION
## Summary
- migrate config from single `control_tuning` to array of named `control_profiles`
- add `name` field to `ControlTuning` and expose first profile for existing code
- centralize control tuning access with new `ControlTuningProvider`
- update interpolation and steering logic to use provider

## Testing
- `./gradlew :domain:test` *(fails: GSTREAMER_ROOT_ANDROID must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68c3188b86a0832b80798e1084b115e6