### PR TITLE
Add Jetpack Compose implementation for quick config overlay

### DIFF
--- a/control_app/buildSrc/src/main/java/Dependencies.kt
+++ b/control_app/buildSrc/src/main/java/Dependencies.kt
@@ -4,4 +4,6 @@ object Dependencies {
     val buildToolsVersion: String = "33.0.1"
     val androidxVersion: String = "1.7.0"
     val kotlinVersion: String = "1.9.20"
+    val composeBomVersion: String = "2023.10.01"
+    val composeCompilerVersion: String = "1.5.7"
 }

--- a/control_app/domain/build.gradle.kts
+++ b/control_app/domain/build.gradle.kts
@@ -34,16 +34,28 @@ android {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = Dependencies.composeCompilerVersion
+    }
 }
 
 dependencies {
+    implementation(platform("androidx.compose:compose-bom:${Dependencies.composeBomVersion}"))
     implementation("androidx.core:core-ktx:1.10.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.10.0")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material:material")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.13")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/control_app/domain/src/main/java/com/rc/playgrounds/presentation/quickconfig/QuickConfigView.kt
+++ b/control_app/domain/src/main/java/com/rc/playgrounds/presentation/quickconfig/QuickConfigView.kt
@@ -1,7 +1,24 @@
 package com.rc.playgrounds.presentation.quickconfig
 
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.AppCompatTextView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.isVisible
 import com.rc.playgrounds.control.gamepad.GamepadButtonPress
 import com.rc.playgrounds.control.gamepad.GamepadEventStream
 import com.rc.playgrounds.domain.R
@@ -15,27 +32,27 @@ class QuickConfigView(
     private val scope: CoroutineScope,
     private val gamepadEventStream: GamepadEventStream,
 ) {
-    private val currentResolution: AppCompatTextView = activity.findViewById(R.id.current_resolution)
-    private val changeHint: AppCompatTextView = activity.findViewById(R.id.change_hint)
-    private val steerOffset: AppCompatTextView = activity.findViewById(R.id.steer_offset)
-    private val steerOffsetHint: AppCompatTextView = activity.findViewById(R.id.steer_offset_hint)
+    private val composeView: ComposeView = activity.findViewById(R.id.quick_config_compose_view)
+    private val viewModelState = mutableStateOf<QuickConfigViewModel>(QuickConfigViewModel.Hidden)
     private var job: Job? = null
 
     init {
+        composeView.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+        composeView.setContent {
+            QuickConfigContent(viewModelState.value)
+        }
+
         scope.launch {
             quickConfigModel.viewModel
                 .collect { viewModel: QuickConfigViewModel ->
                     job?.cancel()
                     job = null
-                    when (viewModel) {
-                        QuickConfigViewModel.Hidden -> Unit
-                        is QuickConfigViewModel.Visible -> {
-                            currentResolution.text = viewModel.resolution
-                            steerOffset.text = viewModel.steeringOffset
-                            job = scope.launch {
-                                gamepadEventStream.buttonEvents.collect {
-                                    processGampadButtonPress(viewModel, it)
-                                }
+                    viewModelState.value = viewModel
+                    composeView.isVisible = viewModel is QuickConfigViewModel.Visible
+                    if (viewModel is QuickConfigViewModel.Visible) {
+                        job = scope.launch {
+                            gamepadEventStream.buttonEvents.collect {
+                                processGampadButtonPress(viewModel, it)
                             }
                         }
                     }
@@ -59,4 +76,47 @@ class QuickConfigView(
             else -> Unit
         }
     }
+}
+
+@Composable
+private fun QuickConfigContent(viewModel: QuickConfigViewModel) {
+    if (viewModel is QuickConfigViewModel.Visible) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color(0x88000000)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(horizontal = 24.dp),
+            ) {
+                QuickConfigPrimaryText(viewModel.resolution)
+                QuickConfigHintText("up/down to change")
+                QuickConfigPrimaryText(viewModel.steeringOffset)
+                QuickConfigHintText("left/right to change")
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickConfigPrimaryText(text: String) {
+    Text(
+        text = text,
+        fontSize = 28.sp,
+        color = Color.White,
+        textAlign = TextAlign.Center,
+    )
+}
+
+@Composable
+private fun QuickConfigHintText(text: String) {
+    Text(
+        text = text,
+        fontSize = 16.sp,
+        color = Color(0xFFD3D3D3),
+        textAlign = TextAlign.Center,
+    )
 }

--- a/control_app/domain/src/main/res/layout/layer_quick_config.xml
+++ b/control_app/domain/src/main/res/layout/layer_quick_config.xml
@@ -1,42 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/quick_config_container"
+<androidx.compose.ui.platform.ComposeView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/quick_config_compose_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#8000"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:visibility="gone">
-
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/current_resolution"
-        tools:text="640x480"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="28sp" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/change_hint"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="up/down to change"
-        android:textColor="#d3d3d3"
-        android:textSize="16sp" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/steer_offset"
-        tools:text="steering offset: 0.18"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textSize="28sp" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/steer_offset_hint"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="left/right to change"
-        android:textColor="#d3d3d3"
-
-        android:textSize="16sp" />
-</LinearLayout>
+    android:visibility="gone" />


### PR DESCRIPTION
## Summary
- enable Jetpack Compose in the domain module and add the required dependencies
- replace the quick config layout with a ComposeView host
- render the quick config overlay with Jetpack Compose while keeping the existing gamepad interactions

## Testing
- ./gradlew :domain:assemble *(fails: GSTREAMER_ROOT_ANDROID must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68d65eb02b8c832bbd8d69b407e5c63a