### PR TITLE
Add build flag to switch to GStreamer stub module

### DIFF
--- a/control_app/README.md
+++ b/control_app/README.md
@@ -7,6 +7,11 @@ At `local.properties` specify path to gstreamer:
 gstAndroidRoot=/path/to/gstreamer-1.0-android-universal-1.24.12
 ```
 
+If you don't have GStreamer available locally, set the following flag to build against a no-op stub module instead of the native integration:
+```
+gstreamer-stub=true
+```
+
 Now you're ready to build app:
 ```sh
 ./gradlew assembleDebug

--- a/control_app/app/build.gradle.kts
+++ b/control_app/app/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+val gStreamerModule = (rootProject.extra["gstreamerModule"] as? String) ?: ":gstreamer"
+
 android {
     buildToolsVersion = Dependencies.buildToolsVersion
 
@@ -56,7 +58,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":gstreamer"))
+    implementation(project(gStreamerModule))
     implementation(project(":domain"))
     implementation("androidx.media3:media3-ui:1.5.1")
     implementation("androidx.media3:media3-exoplayer:1.5.1")

--- a/control_app/gstreamer-stub/build.gradle.kts
+++ b/control_app/gstreamer-stub/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.rc.playgrounds.gstreamer"
+    compileSdk = Dependencies.targetSdkVersion
+    buildToolsVersion = Dependencies.buildToolsVersion
+
+    defaultConfig {
+        minSdk = Dependencies.minSdkVersion
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+}

--- a/control_app/gstreamer-stub/src/main/java/com/rc/playgrounds/gstreamer/GStreamerFacade.java
+++ b/control_app/gstreamer-stub/src/main/java/com/rc/playgrounds/gstreamer/GStreamerFacade.java
@@ -1,0 +1,25 @@
+package com.rc.playgrounds.gstreamer;
+
+import android.content.Context;
+import android.view.SurfaceView;
+
+/**
+ * Stub implementation used when native GStreamer is unavailable.
+ */
+public class GStreamerFacade {
+    public GStreamerFacade(Context context, SurfaceView surfaceView, Logger logger, String pipeline) {
+        // Intentionally left blank.
+    }
+
+    public void play() {
+        // No-op stub implementation.
+    }
+
+    public void pause() {
+        // No-op stub implementation.
+    }
+
+    public void close() {
+        // No-op stub implementation.
+    }
+}

--- a/control_app/gstreamer-stub/src/main/java/com/rc/playgrounds/gstreamer/Logger.kt
+++ b/control_app/gstreamer-stub/src/main/java/com/rc/playgrounds/gstreamer/Logger.kt
@@ -1,0 +1,6 @@
+package com.rc.playgrounds.gstreamer
+
+interface Logger {
+    fun logError(e: Exception)
+    fun logMessage(message: String)
+}

--- a/control_app/settings.gradle.kts
+++ b/control_app/settings.gradle.kts
@@ -1,3 +1,24 @@
+import java.io.File
+import java.util.Properties
+
+val localProperties = File(rootDir, "local.properties")
+val properties = Properties()
+if (localProperties.exists()) {
+    localProperties.inputStream().use { properties.load(it) }
+}
+
+val useGStreamerStub = properties.getProperty("gstreamer-stub")?.toBoolean() == true
+
 include(":app")
 include(":domain")
-include(":gstreamer")
+
+if (useGStreamerStub) {
+    include(":gstreamer-stub")
+    project(":gstreamer-stub").projectDir = File(rootDir, "gstreamer-stub")
+} else {
+    include(":gstreamer")
+}
+
+gradle.rootProject {
+    extra["gstreamerModule"] = if (useGStreamerStub) ":gstreamer-stub" else ":gstreamer"
+}


### PR DESCRIPTION
## Summary
- add a gstreamer-stub Android library with no-op Logger and GStreamerFacade implementations
- load the stub module when `gstreamer-stub=true` is set in local.properties and otherwise keep the native module
- document the new flag for developers

## Testing
- ./gradlew help

------
https://chatgpt.com/codex/tasks/task_e_68e28d457ccc832bb93db8dc74df8895